### PR TITLE
Design tweaks

### DIFF
--- a/EEditor/MainForm.Designer.cs
+++ b/EEditor/MainForm.Designer.cs
@@ -85,8 +85,6 @@
             this.insertDropButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.imageButton = new System.Windows.Forms.ToolStripMenuItem();
             this.textButton = new System.Windows.Forms.ToolStripMenuItem();
-            this.mazeGeneratorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.backgroundIgnoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.replaceButton = new System.Windows.Forms.ToolStripButton();
             this.unknownToolStrip = new System.Windows.Forms.ToolStrip();
@@ -134,6 +132,7 @@
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.LightToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this.mazeGeneratorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.morphToolStrip.SuspendLayout();
             this.viewToolStrip.SuspendLayout();
             this.settingsToolStrip.SuspendLayout();
@@ -330,7 +329,7 @@
             this.settingsToolStrip.Location = new System.Drawing.Point(612, 0);
             this.settingsToolStrip.Name = "settingsToolStrip";
             this.settingsToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.settingsToolStrip.Size = new System.Drawing.Size(187, 27);
+            this.settingsToolStrip.Size = new System.Drawing.Size(156, 27);
             this.settingsToolStrip.TabIndex = 9;
             // 
             // accountsComboBox
@@ -637,7 +636,8 @@
             this.filledRectangleButton,
             this.circleButton,
             this.filledCircleButton,
-            this.lineButton});
+            this.lineButton,
+            this.mazeGeneratorToolStripMenuItem});
             this.shapesDropButton.Image = global::EEditor.Properties.Resources.shapes;
             this.shapesDropButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.shapesDropButton.Name = "shapesDropButton";
@@ -650,7 +650,7 @@
             this.rectangleButton.Image = global::EEditor.Properties.Resources.rectangle;
             this.rectangleButton.Name = "rectangleButton";
             this.rectangleButton.ShortcutKeyDisplayString = ",";
-            this.rectangleButton.Size = new System.Drawing.Size(206, 22);
+            this.rectangleButton.Size = new System.Drawing.Size(210, 26);
             this.rectangleButton.Text = "Rectangle";
             this.rectangleButton.Click += new System.EventHandler(this.rectangleButton_Click);
             // 
@@ -659,7 +659,7 @@
             this.filledRectangleButton.Image = global::EEditor.Properties.Resources.rectanglefill;
             this.filledRectangleButton.Name = "filledRectangleButton";
             this.filledRectangleButton.ShortcutKeyDisplayString = "CTRL + ,";
-            this.filledRectangleButton.Size = new System.Drawing.Size(206, 22);
+            this.filledRectangleButton.Size = new System.Drawing.Size(210, 26);
             this.filledRectangleButton.Text = "Filled rectangle";
             this.filledRectangleButton.Click += new System.EventHandler(this.filledRectangleButton_Click);
             // 
@@ -668,7 +668,7 @@
             this.circleButton.Image = global::EEditor.Properties.Resources.circle;
             this.circleButton.Name = "circleButton";
             this.circleButton.ShortcutKeyDisplayString = ".";
-            this.circleButton.Size = new System.Drawing.Size(206, 22);
+            this.circleButton.Size = new System.Drawing.Size(210, 26);
             this.circleButton.Text = "Circle";
             this.circleButton.Click += new System.EventHandler(this.circleButton_Click);
             // 
@@ -677,7 +677,7 @@
             this.filledCircleButton.Image = global::EEditor.Properties.Resources.circlefill;
             this.filledCircleButton.Name = "filledCircleButton";
             this.filledCircleButton.ShortcutKeyDisplayString = "CTRL + .";
-            this.filledCircleButton.Size = new System.Drawing.Size(206, 22);
+            this.filledCircleButton.Size = new System.Drawing.Size(210, 26);
             this.filledCircleButton.Text = "Filled circle";
             this.filledCircleButton.Click += new System.EventHandler(this.filledCircleButton_Click);
             // 
@@ -686,7 +686,7 @@
             this.lineButton.Image = global::EEditor.Properties.Resources.line;
             this.lineButton.Name = "lineButton";
             this.lineButton.ShortcutKeyDisplayString = "-";
-            this.lineButton.Size = new System.Drawing.Size(206, 22);
+            this.lineButton.Size = new System.Drawing.Size(210, 26);
             this.lineButton.Text = "Line";
             this.lineButton.Click += new System.EventHandler(this.lineButton_Click);
             // 
@@ -695,9 +695,7 @@
             this.insertDropButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.insertDropButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.imageButton,
-            this.textButton,
-            this.mazeGeneratorToolStripMenuItem,
-            this.backgroundIgnoreToolStripMenuItem});
+            this.textButton});
             this.insertDropButton.Image = global::EEditor.Properties.Resources.insert;
             this.insertDropButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.insertDropButton.Name = "insertDropButton";
@@ -710,7 +708,7 @@
             this.imageButton.Image = global::EEditor.Properties.Resources.image;
             this.imageButton.Name = "imageButton";
             this.imageButton.ShortcutKeyDisplayString = "CTRL + I";
-            this.imageButton.Size = new System.Drawing.Size(175, 22);
+            this.imageButton.Size = new System.Drawing.Size(184, 26);
             this.imageButton.Text = "Image";
             this.imageButton.Click += new System.EventHandler(this.imageButton_Click);
             // 
@@ -719,26 +717,9 @@
             this.textButton.Image = global::EEditor.Properties.Resources.text;
             this.textButton.Name = "textButton";
             this.textButton.ShortcutKeyDisplayString = "CTRL + T";
-            this.textButton.Size = new System.Drawing.Size(175, 22);
+            this.textButton.Size = new System.Drawing.Size(184, 26);
             this.textButton.Text = "Text";
             this.textButton.Click += new System.EventHandler(this.textButton_Click);
-            // 
-            // mazeGeneratorToolStripMenuItem
-            // 
-            this.mazeGeneratorToolStripMenuItem.Image = global::EEditor.Properties.Resources.maze;
-            this.mazeGeneratorToolStripMenuItem.Name = "mazeGeneratorToolStripMenuItem";
-            this.mazeGeneratorToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
-            this.mazeGeneratorToolStripMenuItem.Text = "Maze Generator";
-            this.mazeGeneratorToolStripMenuItem.Visible = false;
-            this.mazeGeneratorToolStripMenuItem.Click += new System.EventHandler(this.mazeGeneratorToolStripMenuItem_Click);
-            // 
-            // backgroundIgnoreToolStripMenuItem
-            // 
-            this.backgroundIgnoreToolStripMenuItem.Image = global::EEditor.Properties.Resources.eeditor_bgIgnore;
-            this.backgroundIgnoreToolStripMenuItem.Name = "backgroundIgnoreToolStripMenuItem";
-            this.backgroundIgnoreToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
-            this.backgroundIgnoreToolStripMenuItem.Text = "Background Ignore";
-            this.backgroundIgnoreToolStripMenuItem.Click += new System.EventHandler(this.backgroundIgnoreToolStripMenuItem_Click);
             // 
             // toolStripSeparator8
             // 
@@ -1216,6 +1197,14 @@
             this.toolStripSeparator10.Name = "toolStripSeparator10";
             this.toolStripSeparator10.Size = new System.Drawing.Size(6, 27);
             // 
+            // mazeGeneratorToolStripMenuItem
+            // 
+            this.mazeGeneratorToolStripMenuItem.Image = global::EEditor.Properties.Resources.maze;
+            this.mazeGeneratorToolStripMenuItem.Name = "mazeGeneratorToolStripMenuItem";
+            this.mazeGeneratorToolStripMenuItem.Size = new System.Drawing.Size(210, 26);
+            this.mazeGeneratorToolStripMenuItem.Text = "Maze Generator";
+            this.mazeGeneratorToolStripMenuItem.Visible = false;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1361,9 +1350,7 @@
         private System.Windows.Forms.ToolStripButton lastUsedBlockButton2;
         private System.Windows.Forms.ToolStripButton lastUsedBlockButton3;
         private System.Windows.Forms.ToolStripButton lastUsedBlockButton4;
-        private System.Windows.Forms.ToolStripMenuItem backgroundIgnoreToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem roomDatabaseToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem mazeGeneratorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem eEditor37ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem myOwnWorldsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem eEditor38ToolStripMenuItem;
@@ -1374,6 +1361,7 @@
         private System.Windows.Forms.ToolStripMenuItem eelvlToolStripMenuItem1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
         private System.Windows.Forms.ToolStripButton StatisticButton;
+        private System.Windows.Forms.ToolStripMenuItem mazeGeneratorToolStripMenuItem;
     }
 }
 

--- a/EEditor/MainForm.Designer.cs
+++ b/EEditor/MainForm.Designer.cs
@@ -326,7 +326,7 @@
             this.accountsComboBox,
             this.settingsButton,
             this.aboutButton});
-            this.settingsToolStrip.Location = new System.Drawing.Point(612, 0);
+            this.settingsToolStrip.Location = new System.Drawing.Point(643, 0);
             this.settingsToolStrip.Name = "settingsToolStrip";
             this.settingsToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.settingsToolStrip.Size = new System.Drawing.Size(156, 27);
@@ -375,7 +375,7 @@
             this.fileToolStrip.Location = new System.Drawing.Point(0, 0);
             this.fileToolStrip.Name = "fileToolStrip";
             this.fileToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.fileToolStrip.Size = new System.Drawing.Size(96, 27);
+            this.fileToolStrip.Size = new System.Drawing.Size(127, 27);
             this.fileToolStrip.TabIndex = 7;
             // 
             // newWorldButton
@@ -437,14 +437,14 @@
             // 
             this.eEditor37ToolStripMenuItem.Name = "eEditor37ToolStripMenuItem";
             this.eEditor37ToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.eEditor37ToolStripMenuItem.Text = "EEditor 3.7+";
+            this.eEditor37ToolStripMenuItem.Text = "EEditor 3.7";
             this.eEditor37ToolStripMenuItem.Click += new System.EventHandler(this.eEditor37ToolStripMenuItem_Click);
             // 
             // new33ToolStripMenuItem
             // 
             this.new33ToolStripMenuItem.Name = "new33ToolStripMenuItem";
             this.new33ToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.new33ToolStripMenuItem.Text = "EEditor 3.3+";
+            this.new33ToolStripMenuItem.Text = "EEditor 3.3 - 3.6";
             this.new33ToolStripMenuItem.Click += new System.EventHandler(this.new33ToolStripMenuItem_Click);
             // 
             // loadNewMenuItem
@@ -569,7 +569,7 @@
             this.insertDropButton,
             this.toolStripSeparator8,
             this.replaceButton});
-            this.toolToolStrip.Location = new System.Drawing.Point(96, 0);
+            this.toolToolStrip.Location = new System.Drawing.Point(127, 0);
             this.toolToolStrip.Name = "toolToolStrip";
             this.toolToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.toolToolStrip.Size = new System.Drawing.Size(204, 27);
@@ -799,7 +799,7 @@
             this.refreshButton,
             this.codeTextbox,
             this.uploadButton});
-            this.uploadToolStrip.Location = new System.Drawing.Point(402, 0);
+            this.uploadToolStrip.Location = new System.Drawing.Point(433, 0);
             this.uploadToolStrip.Name = "uploadToolStrip";
             this.uploadToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.uploadToolStrip.Size = new System.Drawing.Size(210, 27);
@@ -871,7 +871,7 @@
             this.redoButton,
             this.historyButton,
             this.StatisticButton});
-            this.historyToolStrip.Location = new System.Drawing.Point(300, 0);
+            this.historyToolStrip.Location = new System.Drawing.Point(331, 0);
             this.historyToolStrip.Name = "historyToolStrip";
             this.historyToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.historyToolStrip.Size = new System.Drawing.Size(102, 27);

--- a/EEditor/MainForm.Designer.cs
+++ b/EEditor/MainForm.Designer.cs
@@ -47,11 +47,11 @@
             this.accountsComboBox = new System.Windows.Forms.ToolStripComboBox();
             this.settingsButton = new System.Windows.Forms.ToolStripButton();
             this.aboutButton = new System.Windows.Forms.ToolStripButton();
-            this.StatisticButton = new System.Windows.Forms.ToolStripButton();
             this.fileToolStrip = new System.Windows.Forms.ToolStrip();
             this.newWorldButton = new System.Windows.Forms.ToolStripButton();
             this.openWorldDropButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.eEditor38ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.eELVLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.eEditor37ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.new33ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -61,7 +61,6 @@
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.savToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.eEBuilderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.eELVLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.roomDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.myOwnWorldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -106,6 +105,7 @@
             this.undoButton = new System.Windows.Forms.ToolStripButton();
             this.redoButton = new System.Windows.Forms.ToolStripButton();
             this.historyButton = new System.Windows.Forms.ToolStripButton();
+            this.StatisticButton = new System.Windows.Forms.ToolStripButton();
             this.panel1 = new System.Windows.Forms.Panel();
             this.flowLayoutPanel6 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
@@ -326,12 +326,11 @@
             this.settingsToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.accountsComboBox,
             this.settingsButton,
-            this.aboutButton,
-            this.StatisticButton});
-            this.settingsToolStrip.Location = new System.Drawing.Point(619, 0);
+            this.aboutButton});
+            this.settingsToolStrip.Location = new System.Drawing.Point(612, 0);
             this.settingsToolStrip.Name = "settingsToolStrip";
             this.settingsToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.settingsToolStrip.Size = new System.Drawing.Size(180, 27);
+            this.settingsToolStrip.Size = new System.Drawing.Size(187, 27);
             this.settingsToolStrip.TabIndex = 9;
             // 
             // accountsComboBox
@@ -366,15 +365,6 @@
             this.aboutButton.ToolTipText = "About EEditor (F1)";
             this.aboutButton.Click += new System.EventHandler(this.aboutButton_Click);
             // 
-            // StatisticButton
-            // 
-            this.StatisticButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.StatisticButton.Image = global::EEditor.Properties.Resources.statistic;
-            this.StatisticButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.StatisticButton.Name = "StatisticButton";
-            this.StatisticButton.Size = new System.Drawing.Size(24, 24);
-            this.StatisticButton.Click += new System.EventHandler(this.StatisticButton_Click);
-            // 
             // fileToolStrip
             // 
             this.fileToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
@@ -386,7 +376,7 @@
             this.fileToolStrip.Location = new System.Drawing.Point(0, 0);
             this.fileToolStrip.Name = "fileToolStrip";
             this.fileToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.fileToolStrip.Size = new System.Drawing.Size(127, 27);
+            this.fileToolStrip.Size = new System.Drawing.Size(96, 27);
             this.fileToolStrip.TabIndex = 7;
             // 
             // newWorldButton
@@ -405,6 +395,7 @@
             this.openWorldDropButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.openWorldDropButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.eEditor38ToolStripMenuItem,
+            this.eELVLToolStripMenuItem,
             this.toolStripSeparator5,
             this.eEditor37ToolStripMenuItem,
             this.new33ToolStripMenuItem,
@@ -414,7 +405,6 @@
             this.toolStripSeparator3,
             this.savToolStripMenuItem,
             this.eEBuilderToolStripMenuItem,
-            this.eELVLToolStripMenuItem,
             this.roomDatabaseToolStripMenuItem,
             this.toolStripSeparator11,
             this.myOwnWorldsToolStripMenuItem});
@@ -431,6 +421,13 @@
             this.eEditor38ToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
             this.eEditor38ToolStripMenuItem.Text = "EEditor 3.8+";
             this.eEditor38ToolStripMenuItem.Click += new System.EventHandler(this.eEditor38ToolStripMenuItem_Click);
+            // 
+            // eELVLToolStripMenuItem
+            // 
+            this.eELVLToolStripMenuItem.Name = "eELVLToolStripMenuItem";
+            this.eELVLToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.eELVLToolStripMenuItem.Text = "EE Offline Level";
+            this.eELVLToolStripMenuItem.Click += new System.EventHandler(this.eELVLToolStripMenuItem_Click);
             // 
             // toolStripSeparator5
             // 
@@ -491,13 +488,6 @@
             this.eEBuilderToolStripMenuItem.Text = "EEBuilder";
             this.eEBuilderToolStripMenuItem.Click += new System.EventHandler(this.eEBuilderToolStripMenuItem_Click);
             // 
-            // eELVLToolStripMenuItem
-            // 
-            this.eELVLToolStripMenuItem.Name = "eELVLToolStripMenuItem";
-            this.eELVLToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.eELVLToolStripMenuItem.Text = "Offline Level";
-            this.eELVLToolStripMenuItem.Click += new System.EventHandler(this.eELVLToolStripMenuItem_Click);
-            // 
             // roomDatabaseToolStripMenuItem
             // 
             this.roomDatabaseToolStripMenuItem.Name = "roomDatabaseToolStripMenuItem";
@@ -537,14 +527,14 @@
             // 
             this.saveWorldToolStripMenuItem.Name = "saveWorldToolStripMenuItem";
             this.saveWorldToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
-            this.saveWorldToolStripMenuItem.Text = "World";
+            this.saveWorldToolStripMenuItem.Text = "EEditor World";
             this.saveWorldToolStripMenuItem.Click += new System.EventHandler(this.saveWorldToolStripMenuItem_Click);
             // 
             // eelvlToolStripMenuItem1
             // 
             this.eelvlToolStripMenuItem1.Name = "eelvlToolStripMenuItem1";
             this.eelvlToolStripMenuItem1.Size = new System.Drawing.Size(172, 22);
-            this.eelvlToolStripMenuItem1.Text = "Offline Level";
+            this.eelvlToolStripMenuItem1.Text = "EE Offline Level";
             this.eelvlToolStripMenuItem1.Click += new System.EventHandler(this.EelvlToolStripMenuItem1_Click);
             // 
             // toolStripSeparator4
@@ -580,7 +570,7 @@
             this.insertDropButton,
             this.toolStripSeparator8,
             this.replaceButton});
-            this.toolToolStrip.Location = new System.Drawing.Point(127, 0);
+            this.toolToolStrip.Location = new System.Drawing.Point(96, 0);
             this.toolToolStrip.Name = "toolToolStrip";
             this.toolToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.toolToolStrip.Size = new System.Drawing.Size(204, 27);
@@ -660,7 +650,7 @@
             this.rectangleButton.Image = global::EEditor.Properties.Resources.rectangle;
             this.rectangleButton.Name = "rectangleButton";
             this.rectangleButton.ShortcutKeyDisplayString = ",";
-            this.rectangleButton.Size = new System.Drawing.Size(205, 22);
+            this.rectangleButton.Size = new System.Drawing.Size(206, 22);
             this.rectangleButton.Text = "Rectangle";
             this.rectangleButton.Click += new System.EventHandler(this.rectangleButton_Click);
             // 
@@ -669,7 +659,7 @@
             this.filledRectangleButton.Image = global::EEditor.Properties.Resources.rectanglefill;
             this.filledRectangleButton.Name = "filledRectangleButton";
             this.filledRectangleButton.ShortcutKeyDisplayString = "CTRL + ,";
-            this.filledRectangleButton.Size = new System.Drawing.Size(205, 22);
+            this.filledRectangleButton.Size = new System.Drawing.Size(206, 22);
             this.filledRectangleButton.Text = "Filled rectangle";
             this.filledRectangleButton.Click += new System.EventHandler(this.filledRectangleButton_Click);
             // 
@@ -678,7 +668,7 @@
             this.circleButton.Image = global::EEditor.Properties.Resources.circle;
             this.circleButton.Name = "circleButton";
             this.circleButton.ShortcutKeyDisplayString = ".";
-            this.circleButton.Size = new System.Drawing.Size(205, 22);
+            this.circleButton.Size = new System.Drawing.Size(206, 22);
             this.circleButton.Text = "Circle";
             this.circleButton.Click += new System.EventHandler(this.circleButton_Click);
             // 
@@ -687,7 +677,7 @@
             this.filledCircleButton.Image = global::EEditor.Properties.Resources.circlefill;
             this.filledCircleButton.Name = "filledCircleButton";
             this.filledCircleButton.ShortcutKeyDisplayString = "CTRL + .";
-            this.filledCircleButton.Size = new System.Drawing.Size(205, 22);
+            this.filledCircleButton.Size = new System.Drawing.Size(206, 22);
             this.filledCircleButton.Text = "Filled circle";
             this.filledCircleButton.Click += new System.EventHandler(this.filledCircleButton_Click);
             // 
@@ -696,7 +686,7 @@
             this.lineButton.Image = global::EEditor.Properties.Resources.line;
             this.lineButton.Name = "lineButton";
             this.lineButton.ShortcutKeyDisplayString = "-";
-            this.lineButton.Size = new System.Drawing.Size(205, 22);
+            this.lineButton.Size = new System.Drawing.Size(206, 22);
             this.lineButton.Text = "Line";
             this.lineButton.Click += new System.EventHandler(this.lineButton_Click);
             // 
@@ -802,7 +792,6 @@
             // 
             // delayTextBox
             // 
-            this.delayTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.delayTextBox.Name = "delayTextBox";
             this.delayTextBox.Size = new System.Drawing.Size(40, 25);
             this.delayTextBox.Text = "-Delay-";
@@ -829,7 +818,7 @@
             this.refreshButton,
             this.codeTextbox,
             this.uploadButton});
-            this.uploadToolStrip.Location = new System.Drawing.Point(409, 0);
+            this.uploadToolStrip.Location = new System.Drawing.Point(402, 0);
             this.uploadToolStrip.Name = "uploadToolStrip";
             this.uploadToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.uploadToolStrip.Size = new System.Drawing.Size(210, 27);
@@ -837,7 +826,6 @@
             // 
             // levelTextbox
             // 
-            this.levelTextbox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.levelTextbox.Name = "levelTextbox";
             this.levelTextbox.Size = new System.Drawing.Size(76, 27);
             this.levelTextbox.Text = "Level ID";
@@ -859,7 +847,6 @@
             // 
             // codeTextbox
             // 
-            this.codeTextbox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.codeTextbox.Name = "codeTextbox";
             this.codeTextbox.Size = new System.Drawing.Size(76, 27);
             this.codeTextbox.Text = "Code";
@@ -901,11 +888,12 @@
             this.historyToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.undoButton,
             this.redoButton,
-            this.historyButton});
-            this.historyToolStrip.Location = new System.Drawing.Point(331, 0);
+            this.historyButton,
+            this.StatisticButton});
+            this.historyToolStrip.Location = new System.Drawing.Point(300, 0);
             this.historyToolStrip.Name = "historyToolStrip";
             this.historyToolStrip.Padding = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.historyToolStrip.Size = new System.Drawing.Size(78, 27);
+            this.historyToolStrip.Size = new System.Drawing.Size(102, 27);
             this.historyToolStrip.TabIndex = 10;
             this.historyToolStrip.Text = "toolStrip1";
             // 
@@ -944,6 +932,15 @@
             this.historyButton.Text = "History";
             this.historyButton.ToolTipText = "Show action history (Ctrl + Shift + H)";
             this.historyButton.Click += new System.EventHandler(this.historyButton_Click);
+            // 
+            // StatisticButton
+            // 
+            this.StatisticButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.StatisticButton.Image = global::EEditor.Properties.Resources.statistic;
+            this.StatisticButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.StatisticButton.Name = "StatisticButton";
+            this.StatisticButton.Size = new System.Drawing.Size(24, 24);
+            this.StatisticButton.Click += new System.EventHandler(this.StatisticButton_Click);
             // 
             // panel1
             // 
@@ -1113,7 +1110,6 @@
             // 
             // filterTextBox
             // 
-            this.filterTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.filterTextBox.Name = "filterTextBox";
             this.filterTextBox.Size = new System.Drawing.Size(100, 27);
             this.filterTextBox.ToolTipText = "Filter blocks by pack (Enter to search)";
@@ -1375,9 +1371,9 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
         private System.Windows.Forms.ToolStripMenuItem eELVLToolStripMenuItem;
-        private System.Windows.Forms.ToolStripButton StatisticButton;
         private System.Windows.Forms.ToolStripMenuItem eelvlToolStripMenuItem1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
+        private System.Windows.Forms.ToolStripButton StatisticButton;
     }
 }
 

--- a/EEditor/MainForm.cs
+++ b/EEditor/MainForm.cs
@@ -4416,12 +4416,6 @@ namespace EEditor
         {
         }
 
-        private void backgroundIgnoreToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            BackgroundIgnore bgi = new BackgroundIgnore();
-            bgi.Show();
-        }
-
         private void localToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SetDummy();

--- a/EEditor/MainForm.resx
+++ b/EEditor/MainForm.resx
@@ -242,15 +242,6 @@
   <metadata name="lastUsedToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>284, 48</value>
   </metadata>
-  <metadata name="statusToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>868, 9</value>
-  </metadata>
-  <metadata name="findToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1001, 9</value>
-  </metadata>
-  <metadata name="lastUsedToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>284, 48</value>
-  </metadata>
   <data name="lastUsedBlockButton0.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8

--- a/EEditor/MainForm.resx
+++ b/EEditor/MainForm.resx
@@ -242,6 +242,15 @@
   <metadata name="lastUsedToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>284, 48</value>
   </metadata>
+  <metadata name="statusToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>868, 9</value>
+  </metadata>
+  <metadata name="findToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1001, 9</value>
+  </metadata>
+  <metadata name="lastUsedToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>284, 48</value>
+  </metadata>
   <data name="lastUsedBlockButton0.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8

--- a/EEditor/Replacer.Designer.cs
+++ b/EEditor/Replacer.Designer.cs
@@ -63,6 +63,7 @@
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.ReplaceUnknownCheckBox = new System.Windows.Forms.CheckBox();
             this.NormalRadioButton = new System.Windows.Forms.RadioButton();
             this.RotationPictureBox2 = new System.Windows.Forms.PictureBox();
             this.RotationPictureBox1 = new System.Windows.Forms.PictureBox();
@@ -159,6 +160,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.ReplaceUnknownCheckBox);
             this.groupBox1.Controls.Add(this.ClearBgsBlacklistButton);
             this.groupBox1.Controls.Add(this.button9);
             this.groupBox1.Controls.Add(this.button5);
@@ -169,27 +171,27 @@
             this.groupBox1.Controls.Add(this.button8);
             this.groupBox1.Location = new System.Drawing.Point(270, 5);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(278, 349);
+            this.groupBox1.Size = new System.Drawing.Size(278, 410);
             this.groupBox1.TabIndex = 12;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Find && replace";
             // 
             // ClearBgsBlacklistButton
             // 
-            this.ClearBgsBlacklistButton.Location = new System.Drawing.Point(152, 319);
+            this.ClearBgsBlacklistButton.Location = new System.Drawing.Point(139, 378);
             this.ClearBgsBlacklistButton.Name = "ClearBgsBlacklistButton";
-            this.ClearBgsBlacklistButton.Size = new System.Drawing.Size(108, 24);
+            this.ClearBgsBlacklistButton.Size = new System.Drawing.Size(121, 21);
             this.ClearBgsBlacklistButton.TabIndex = 18;
-            this.ClearBgsBlacklistButton.Text = "Block bg blacklist";
+            this.ClearBgsBlacklistButton.Text = "Exceptions";
             this.ClearBgsBlacklistButton.UseVisualStyleBackColor = true;
             this.ClearBgsBlacklistButton.Click += new System.EventHandler(this.ClearBgsBlacklistButton_Click);
             // 
             // button9
             // 
             this.button9.Enabled = false;
-            this.button9.Location = new System.Drawing.Point(152, 280);
+            this.button9.Location = new System.Drawing.Point(139, 303);
             this.button9.Name = "button9";
-            this.button9.Size = new System.Drawing.Size(108, 21);
+            this.button9.Size = new System.Drawing.Size(121, 33);
             this.button9.TabIndex = 17;
             this.button9.Text = "Replace unowned";
             this.button9.UseVisualStyleBackColor = true;
@@ -199,9 +201,9 @@
             // 
             this.button5.Image = ((System.Drawing.Image)(resources.GetObject("button5.Image")));
             this.button5.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.button5.Location = new System.Drawing.Point(152, 202);
+            this.button5.Location = new System.Drawing.Point(139, 202);
             this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(108, 33);
+            this.button5.Size = new System.Drawing.Size(121, 33);
             this.button5.TabIndex = 10;
             this.button5.Text = "Replace next";
             this.button5.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -214,7 +216,7 @@
             this.button4.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.button4.Location = new System.Drawing.Point(17, 202);
             this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(96, 33);
+            this.button4.Size = new System.Drawing.Size(106, 33);
             this.button4.TabIndex = 9;
             this.button4.Text = "Find next";
             this.button4.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -225,10 +227,10 @@
             // 
             this.button1.Image = global::EEditor.Properties.Resources.replace_all;
             this.button1.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.button1.Location = new System.Drawing.Point(152, 241);
+            this.button1.Location = new System.Drawing.Point(139, 241);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(108, 33);
+            this.button1.Size = new System.Drawing.Size(121, 33);
             this.button1.TabIndex = 4;
             this.button1.Text = "Replace all";
             this.button1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -239,11 +241,11 @@
             // 
             this.ClearBgsButton.Image = global::EEditor.Properties.Resources.eeditor_bgIgnore;
             this.ClearBgsButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.ClearBgsButton.Location = new System.Drawing.Point(17, 319);
+            this.ClearBgsButton.Location = new System.Drawing.Point(139, 345);
             this.ClearBgsButton.Name = "ClearBgsButton";
-            this.ClearBgsButton.Size = new System.Drawing.Size(96, 24);
+            this.ClearBgsButton.Size = new System.Drawing.Size(121, 36);
             this.ClearBgsButton.TabIndex = 0;
-            this.ClearBgsButton.Text = "Clear block bg";
+            this.ClearBgsButton.Text = "Clear block background";
             this.ClearBgsButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.ClearBgsButton.UseVisualStyleBackColor = true;
             this.ClearBgsButton.Click += new System.EventHandler(this.ClearBgsButton_Click);
@@ -254,7 +256,7 @@
             this.button3.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.button3.Location = new System.Drawing.Point(17, 241);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(96, 33);
+            this.button3.Size = new System.Drawing.Size(106, 33);
             this.button3.TabIndex = 8;
             this.button3.Text = "Find all";
             this.button3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -263,9 +265,9 @@
             // 
             // button8
             // 
-            this.button8.Location = new System.Drawing.Point(17, 280);
+            this.button8.Location = new System.Drawing.Point(17, 366);
             this.button8.Name = "button8";
-            this.button8.Size = new System.Drawing.Size(96, 21);
+            this.button8.Size = new System.Drawing.Size(106, 33);
             this.button8.TabIndex = 16;
             this.button8.Text = "Reset search";
             this.button8.UseVisualStyleBackColor = true;
@@ -401,7 +403,7 @@
             this.groupBox2.Controls.Add(this.toolStripContainer1);
             this.groupBox2.Location = new System.Drawing.Point(12, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(252, 349);
+            this.groupBox2.Size = new System.Drawing.Size(252, 410);
             this.groupBox2.TabIndex = 13;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Get block ID by pack";
@@ -432,12 +434,12 @@
             this.toolStripContainer1.ContentPanel.AutoScroll = true;
             this.toolStripContainer1.ContentPanel.Controls.Add(this.toolStrip1);
             this.toolStripContainer1.ContentPanel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(241, 301);
+            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(241, 357);
             this.toolStripContainer1.LeftToolStripPanelVisible = false;
             this.toolStripContainer1.Location = new System.Drawing.Point(5, 42);
             this.toolStripContainer1.Name = "toolStripContainer1";
             this.toolStripContainer1.RightToolStripPanelVisible = false;
-            this.toolStripContainer1.Size = new System.Drawing.Size(241, 301);
+            this.toolStripContainer1.Size = new System.Drawing.Size(241, 357);
             this.toolStripContainer1.TabIndex = 11;
             this.toolStripContainer1.Text = "toolStripContainer1";
             this.toolStripContainer1.TopToolStripPanelVisible = false;
@@ -458,7 +460,7 @@
             // 
             this.groupBox5.Controls.Add(this.progressBar1);
             this.groupBox5.Controls.Add(this.label4);
-            this.groupBox5.Location = new System.Drawing.Point(12, 360);
+            this.groupBox5.Location = new System.Drawing.Point(12, 421);
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.Size = new System.Drawing.Size(536, 42);
             this.groupBox5.TabIndex = 16;
@@ -507,6 +509,17 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Normal";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // ReplaceUnknownCheckBox
+            // 
+            this.ReplaceUnknownCheckBox.AutoSize = true;
+            this.ReplaceUnknownCheckBox.Location = new System.Drawing.Point(147, 280);
+            this.ReplaceUnknownCheckBox.Name = "ReplaceUnknownCheckBox";
+            this.ReplaceUnknownCheckBox.Size = new System.Drawing.Size(113, 17);
+            this.ReplaceUnknownCheckBox.TabIndex = 19;
+            this.ReplaceUnknownCheckBox.Text = "Replace unknown";
+            this.ReplaceUnknownCheckBox.UseVisualStyleBackColor = true;
+            this.ReplaceUnknownCheckBox.CheckedChanged += new System.EventHandler(this.ReplaceUnknownCheckBox_CheckedChanged);
             // 
             // NormalRadioButton
             // 
@@ -855,7 +868,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(558, 414);
+            this.ClientSize = new System.Drawing.Size(558, 474);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.groupBox2);
@@ -868,6 +881,7 @@
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Replacer_FormClosed);
             this.Load += new System.EventHandler(this.Replacer_Load);
             this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.replaceRotate)).EndInit();
@@ -969,5 +983,6 @@
         private System.Windows.Forms.PictureBox RotationPictureBox1;
         private System.Windows.Forms.RadioButton NormalRadioButton;
         private System.Windows.Forms.Button ClearBgsBlacklistButton;
+        private System.Windows.Forms.CheckBox ReplaceUnknownCheckBox;
     }
 }

--- a/EEditor/Replacer.Designer.cs
+++ b/EEditor/Replacer.Designer.cs
@@ -35,6 +35,7 @@
             this.LeftToolStripPanel = new System.Windows.Forms.ToolStripPanel();
             this.ContentPanel = new System.Windows.Forms.ToolStripContentPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.ClearBgsBlacklistButton = new System.Windows.Forms.Button();
             this.button9 = new System.Windows.Forms.Button();
             this.button5 = new System.Windows.Forms.Button();
             this.button4 = new System.Windows.Forms.Button();
@@ -62,6 +63,7 @@
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.NormalRadioButton = new System.Windows.Forms.RadioButton();
             this.RotationPictureBox2 = new System.Windows.Forms.PictureBox();
             this.RotationPictureBox1 = new System.Windows.Forms.PictureBox();
             this.label6 = new System.Windows.Forms.Label();
@@ -91,7 +93,6 @@
             this.label15 = new System.Windows.Forms.Label();
             this.WorldPortalRadioButton = new System.Windows.Forms.RadioButton();
             this.SignRadioButton = new System.Windows.Forms.RadioButton();
-            this.NormalRadioButton = new System.Windows.Forms.RadioButton();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon1)).BeginInit();
@@ -158,6 +159,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.ClearBgsBlacklistButton);
             this.groupBox1.Controls.Add(this.button9);
             this.groupBox1.Controls.Add(this.button5);
             this.groupBox1.Controls.Add(this.button4);
@@ -171,6 +173,16 @@
             this.groupBox1.TabIndex = 12;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Find && replace";
+            // 
+            // ClearBgsBlacklistButton
+            // 
+            this.ClearBgsBlacklistButton.Location = new System.Drawing.Point(152, 319);
+            this.ClearBgsBlacklistButton.Name = "ClearBgsBlacklistButton";
+            this.ClearBgsBlacklistButton.Size = new System.Drawing.Size(108, 24);
+            this.ClearBgsBlacklistButton.TabIndex = 18;
+            this.ClearBgsBlacklistButton.Text = "Block bg blacklist";
+            this.ClearBgsBlacklistButton.UseVisualStyleBackColor = true;
+            this.ClearBgsBlacklistButton.Click += new System.EventHandler(this.ClearBgsBlacklistButton_Click);
             // 
             // button9
             // 
@@ -225,11 +237,14 @@
             // 
             // ClearBgsButton
             // 
-            this.ClearBgsButton.Location = new System.Drawing.Point(152, 307);
+            this.ClearBgsButton.Image = global::EEditor.Properties.Resources.eeditor_bgIgnore;
+            this.ClearBgsButton.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.ClearBgsButton.Location = new System.Drawing.Point(17, 319);
             this.ClearBgsButton.Name = "ClearBgsButton";
-            this.ClearBgsButton.Size = new System.Drawing.Size(108, 36);
+            this.ClearBgsButton.Size = new System.Drawing.Size(96, 24);
             this.ClearBgsButton.TabIndex = 0;
-            this.ClearBgsButton.Text = "Clear bgs behind blocks";
+            this.ClearBgsButton.Text = "Clear block bg";
+            this.ClearBgsButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.ClearBgsButton.UseVisualStyleBackColor = true;
             this.ClearBgsButton.Click += new System.EventHandler(this.ClearBgsButton_Click);
             // 
@@ -492,6 +507,19 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Normal";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // NormalRadioButton
+            // 
+            this.NormalRadioButton.AutoSize = true;
+            this.NormalRadioButton.Checked = true;
+            this.NormalRadioButton.Location = new System.Drawing.Point(11, 98);
+            this.NormalRadioButton.Name = "NormalRadioButton";
+            this.NormalRadioButton.Size = new System.Drawing.Size(58, 17);
+            this.NormalRadioButton.TabIndex = 26;
+            this.NormalRadioButton.TabStop = true;
+            this.NormalRadioButton.Text = "Normal";
+            this.NormalRadioButton.UseVisualStyleBackColor = true;
+            this.NormalRadioButton.Click += new System.EventHandler(this.NormalRadioButton_Click);
             // 
             // RotationPictureBox2
             // 
@@ -823,19 +851,6 @@
             this.SignRadioButton.UseVisualStyleBackColor = true;
             this.SignRadioButton.Click += new System.EventHandler(this.SignRadioButton_Click);
             // 
-            // NormalRadioButton
-            // 
-            this.NormalRadioButton.AutoSize = true;
-            this.NormalRadioButton.Checked = true;
-            this.NormalRadioButton.Location = new System.Drawing.Point(11, 98);
-            this.NormalRadioButton.Name = "NormalRadioButton";
-            this.NormalRadioButton.Size = new System.Drawing.Size(58, 17);
-            this.NormalRadioButton.TabIndex = 26;
-            this.NormalRadioButton.TabStop = true;
-            this.NormalRadioButton.Text = "Normal";
-            this.NormalRadioButton.UseVisualStyleBackColor = true;
-            this.NormalRadioButton.Click += new System.EventHandler(this.NormalRadioButton_Click);
-            // 
             // Replacer
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -953,5 +968,6 @@
         private System.Windows.Forms.PictureBox RotationPictureBox2;
         private System.Windows.Forms.PictureBox RotationPictureBox1;
         private System.Windows.Forms.RadioButton NormalRadioButton;
+        private System.Windows.Forms.Button ClearBgsBlacklistButton;
     }
 }

--- a/EEditor/Replacer.Designer.cs
+++ b/EEditor/Replacer.Designer.cs
@@ -62,7 +62,6 @@
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.NormalRadioButton = new System.Windows.Forms.RadioButton();
             this.RotationPictureBox2 = new System.Windows.Forms.PictureBox();
             this.RotationPictureBox1 = new System.Windows.Forms.PictureBox();
             this.label6 = new System.Windows.Forms.Label();
@@ -92,6 +91,7 @@
             this.label15 = new System.Windows.Forms.Label();
             this.WorldPortalRadioButton = new System.Windows.Forms.RadioButton();
             this.SignRadioButton = new System.Windows.Forms.RadioButton();
+            this.NormalRadioButton = new System.Windows.Forms.RadioButton();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.rotateIcon1)).BeginInit();
@@ -175,9 +175,9 @@
             // button9
             // 
             this.button9.Enabled = false;
-            this.button9.Location = new System.Drawing.Point(152, 253);
+            this.button9.Location = new System.Drawing.Point(152, 280);
             this.button9.Name = "button9";
-            this.button9.Size = new System.Drawing.Size(92, 34);
+            this.button9.Size = new System.Drawing.Size(108, 21);
             this.button9.TabIndex = 17;
             this.button9.Text = "Replace unowned";
             this.button9.UseVisualStyleBackColor = true;
@@ -186,39 +186,48 @@
             // button5
             // 
             this.button5.Image = ((System.Drawing.Image)(resources.GetObject("button5.Image")));
+            this.button5.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.button5.Location = new System.Drawing.Point(152, 202);
             this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(45, 45);
+            this.button5.Size = new System.Drawing.Size(108, 33);
             this.button5.TabIndex = 10;
+            this.button5.Text = "Replace next";
+            this.button5.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.button5.UseVisualStyleBackColor = true;
             this.button5.Click += new System.EventHandler(this.button5_Click);
             // 
             // button4
             // 
             this.button4.Image = global::EEditor.Properties.Resources.find_next;
-            this.button4.Location = new System.Drawing.Point(31, 202);
+            this.button4.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.button4.Location = new System.Drawing.Point(17, 202);
             this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(45, 45);
+            this.button4.Size = new System.Drawing.Size(96, 33);
             this.button4.TabIndex = 9;
+            this.button4.Text = "Find next";
+            this.button4.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.button4.UseVisualStyleBackColor = true;
             this.button4.Click += new System.EventHandler(this.button4_Click);
             // 
             // button1
             // 
             this.button1.Image = global::EEditor.Properties.Resources.replace_all;
-            this.button1.Location = new System.Drawing.Point(199, 202);
+            this.button1.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.button1.Location = new System.Drawing.Point(152, 241);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(45, 45);
+            this.button1.Size = new System.Drawing.Size(108, 33);
             this.button1.TabIndex = 4;
+            this.button1.Text = "Replace all";
+            this.button1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
             // ClearBgsButton
             // 
-            this.ClearBgsButton.Location = new System.Drawing.Point(82, 293);
+            this.ClearBgsButton.Location = new System.Drawing.Point(152, 307);
             this.ClearBgsButton.Name = "ClearBgsButton";
-            this.ClearBgsButton.Size = new System.Drawing.Size(136, 40);
+            this.ClearBgsButton.Size = new System.Drawing.Size(108, 36);
             this.ClearBgsButton.TabIndex = 0;
             this.ClearBgsButton.Text = "Clear bgs behind blocks";
             this.ClearBgsButton.UseVisualStyleBackColor = true;
@@ -227,20 +236,23 @@
             // button3
             // 
             this.button3.Image = ((System.Drawing.Image)(resources.GetObject("button3.Image")));
-            this.button3.Location = new System.Drawing.Point(82, 202);
+            this.button3.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.button3.Location = new System.Drawing.Point(17, 241);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(45, 45);
+            this.button3.Size = new System.Drawing.Size(96, 33);
             this.button3.TabIndex = 8;
+            this.button3.Text = "Find all";
+            this.button3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
             // button8
             // 
-            this.button8.Location = new System.Drawing.Point(28, 253);
+            this.button8.Location = new System.Drawing.Point(17, 280);
             this.button8.Name = "button8";
-            this.button8.Size = new System.Drawing.Size(92, 34);
+            this.button8.Size = new System.Drawing.Size(96, 21);
             this.button8.TabIndex = 16;
-            this.button8.Text = "Reset view";
+            this.button8.Text = "Reset search";
             this.button8.UseVisualStyleBackColor = true;
             this.button8.Click += new System.EventHandler(this.button8_Click);
             // 
@@ -374,7 +386,7 @@
             this.groupBox2.Controls.Add(this.toolStripContainer1);
             this.groupBox2.Location = new System.Drawing.Point(12, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(252, 324);
+            this.groupBox2.Size = new System.Drawing.Size(252, 349);
             this.groupBox2.TabIndex = 13;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Get block ID by pack";
@@ -405,12 +417,12 @@
             this.toolStripContainer1.ContentPanel.AutoScroll = true;
             this.toolStripContainer1.ContentPanel.Controls.Add(this.toolStrip1);
             this.toolStripContainer1.ContentPanel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(241, 276);
+            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(241, 301);
             this.toolStripContainer1.LeftToolStripPanelVisible = false;
             this.toolStripContainer1.Location = new System.Drawing.Point(5, 42);
             this.toolStripContainer1.Name = "toolStripContainer1";
             this.toolStripContainer1.RightToolStripPanelVisible = false;
-            this.toolStripContainer1.Size = new System.Drawing.Size(241, 276);
+            this.toolStripContainer1.Size = new System.Drawing.Size(241, 301);
             this.toolStripContainer1.TabIndex = 11;
             this.toolStripContainer1.Text = "toolStripContainer1";
             this.toolStripContainer1.TopToolStripPanelVisible = false;
@@ -480,19 +492,6 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Normal";
             this.tabPage1.UseVisualStyleBackColor = true;
-            // 
-            // NormalRadioButton
-            // 
-            this.NormalRadioButton.AutoSize = true;
-            this.NormalRadioButton.Checked = true;
-            this.NormalRadioButton.Location = new System.Drawing.Point(11, 98);
-            this.NormalRadioButton.Name = "NormalRadioButton";
-            this.NormalRadioButton.Size = new System.Drawing.Size(58, 17);
-            this.NormalRadioButton.TabIndex = 26;
-            this.NormalRadioButton.TabStop = true;
-            this.NormalRadioButton.Text = "Normal";
-            this.NormalRadioButton.UseVisualStyleBackColor = true;
-            this.NormalRadioButton.Click += new System.EventHandler(this.NormalRadioButton_Click);
             // 
             // RotationPictureBox2
             // 
@@ -823,6 +822,19 @@
             this.SignRadioButton.TabStop = true;
             this.SignRadioButton.UseVisualStyleBackColor = true;
             this.SignRadioButton.Click += new System.EventHandler(this.SignRadioButton_Click);
+            // 
+            // NormalRadioButton
+            // 
+            this.NormalRadioButton.AutoSize = true;
+            this.NormalRadioButton.Checked = true;
+            this.NormalRadioButton.Location = new System.Drawing.Point(11, 98);
+            this.NormalRadioButton.Name = "NormalRadioButton";
+            this.NormalRadioButton.Size = new System.Drawing.Size(58, 17);
+            this.NormalRadioButton.TabIndex = 26;
+            this.NormalRadioButton.TabStop = true;
+            this.NormalRadioButton.Text = "Normal";
+            this.NormalRadioButton.UseVisualStyleBackColor = true;
+            this.NormalRadioButton.Click += new System.EventHandler(this.NormalRadioButton_Click);
             // 
             // Replacer
             // 

--- a/EEditor/Replacer.cs
+++ b/EEditor/Replacer.cs
@@ -1098,5 +1098,11 @@ namespace EEditor
             WorldPortalRadioButton.Checked = true;
             NormalRadioButton.Checked = false;
         }
+
+        private void ClearBgsBlacklistButton_Click(object sender, EventArgs e)
+        {
+            BackgroundIgnore bgi = new BackgroundIgnore();
+            bgi.Show();
+        }
     }
 }

--- a/EEditor/Replacer.cs
+++ b/EEditor/Replacer.cs
@@ -34,6 +34,7 @@ namespace EEditor
             lastBlock = new int[MainForm.editArea.Frames[0].Height, MainForm.editArea.Frames[0].Width];
             MainForm.editArea.Back1 = MainForm.editArea.Back;
             numericUpDown1.Value = MainForm.editArea.Tool.PenID;
+            ReplaceUnknownCheckBox.Checked = MainForm.userdata.replaceit;
 
             PortalRadioButton.Image = MainForm.miscBMD.Clone(new Rectangle(108 * 16, 0, 16, 16), MainForm.miscBMD.PixelFormat);
             PortalINVRadioButton.Image = MainForm.miscBMD.Clone(new Rectangle(112 * 16, 0, 16, 16), MainForm.miscBMD.PixelFormat);
@@ -1103,6 +1104,11 @@ namespace EEditor
         {
             BackgroundIgnore bgi = new BackgroundIgnore();
             bgi.Show();
+        }
+
+        private void ReplaceUnknownCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            MainForm.userdata.replaceit = ReplaceUnknownCheckBox.Checked;
         }
     }
 }

--- a/EEditor/SettingsForm.Designer.cs
+++ b/EEditor/SettingsForm.Designer.cs
@@ -31,7 +31,6 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.usePenToolCheckBox = new System.Windows.Forms.CheckBox();
             this.selectAllBorderCheckBox = new System.Windows.Forms.CheckBox();
-            this.tempLabel = new System.Windows.Forms.Label();
             this.clearComboBox = new System.Windows.Forms.ComboBox();
             this.clearButton = new System.Windows.Forms.Button();
             this.confirmCloseCheckBox = new System.Windows.Forms.CheckBox();
@@ -67,15 +66,6 @@
             this.selectAllBorderCheckBox.Text = "Include borders with select all";
             this.selectAllBorderCheckBox.UseVisualStyleBackColor = true;
             this.selectAllBorderCheckBox.CheckedChanged += new System.EventHandler(this.selectAllBorderCheckBox_CheckedChanged);
-            // 
-            // tempLabel
-            // 
-            this.tempLabel.AutoSize = true;
-            this.tempLabel.Location = new System.Drawing.Point(8, 173);
-            this.tempLabel.Name = "tempLabel";
-            this.tempLabel.Size = new System.Drawing.Size(202, 26);
-            this.tempLabel.TabIndex = 26;
-            this.tempLabel.Text = "Accounts have moved! They are now in  \r\nmain window, on username dropdown.";
             // 
             // clearComboBox
             // 
@@ -122,9 +112,9 @@
             this.checkBox2.AutoSize = true;
             this.checkBox2.Location = new System.Drawing.Point(11, 102);
             this.checkBox2.Name = "checkBox2";
-            this.checkBox2.Size = new System.Drawing.Size(144, 17);
+            this.checkBox2.Size = new System.Drawing.Size(147, 17);
             this.checkBox2.TabIndex = 31;
-            this.checkBox2.Text = "Replace Uknown Blocks";
+            this.checkBox2.Text = "Replace unknown blocks";
             this.checkBox2.UseVisualStyleBackColor = true;
             this.checkBox2.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
             // 
@@ -147,9 +137,9 @@
             this.StatusTextToolStripStatusLabel,
             this.StatusToolStripStatusLabel,
             this.StatusColorToolStripStatusLabel});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 215);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 177);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(238, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(228, 22);
             this.statusStrip1.TabIndex = 31;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -177,7 +167,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(238, 237);
+            this.ClientSize = new System.Drawing.Size(228, 199);
             this.Controls.Add(this.checkBox2);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.FasterShapeStyleCheckBox);
@@ -186,7 +176,6 @@
             this.Controls.Add(this.confirmCloseCheckBox);
             this.Controls.Add(this.clearComboBox);
             this.Controls.Add(this.clearButton);
-            this.Controls.Add(this.tempLabel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "SettingsForm";
@@ -204,7 +193,6 @@
         #endregion
         private System.Windows.Forms.CheckBox usePenToolCheckBox;
         private System.Windows.Forms.CheckBox selectAllBorderCheckBox;
-        private System.Windows.Forms.Label tempLabel;
         private System.Windows.Forms.ComboBox clearComboBox;
         private System.Windows.Forms.Button clearButton;
         private System.Windows.Forms.CheckBox confirmCloseCheckBox;

--- a/EEditor/SettingsForm.Designer.cs
+++ b/EEditor/SettingsForm.Designer.cs
@@ -34,7 +34,6 @@
             this.clearComboBox = new System.Windows.Forms.ComboBox();
             this.clearButton = new System.Windows.Forms.Button();
             this.confirmCloseCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkBox2 = new System.Windows.Forms.CheckBox();
             this.FasterShapeStyleCheckBox = new System.Windows.Forms.CheckBox();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.StatusTextToolStripStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -78,7 +77,7 @@
             "",
             "Old EEditor settings & logins",
             "Current EEditor settings"});
-            this.clearComboBox.Location = new System.Drawing.Point(9, 149);
+            this.clearComboBox.Location = new System.Drawing.Point(11, 117);
             this.clearComboBox.Name = "clearComboBox";
             this.clearComboBox.Size = new System.Drawing.Size(139, 21);
             this.clearComboBox.TabIndex = 27;
@@ -87,7 +86,7 @@
             // clearButton
             // 
             this.clearButton.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.clearButton.Location = new System.Drawing.Point(150, 148);
+            this.clearButton.Location = new System.Drawing.Point(156, 117);
             this.clearButton.Name = "clearButton";
             this.clearButton.Size = new System.Drawing.Size(49, 23);
             this.clearButton.TabIndex = 28;
@@ -106,17 +105,6 @@
             this.confirmCloseCheckBox.Text = "Confirm EEditor exit";
             this.confirmCloseCheckBox.UseVisualStyleBackColor = true;
             this.confirmCloseCheckBox.CheckedChanged += new System.EventHandler(this.confirmCloseCheckBox_CheckedChanged);
-            // 
-            // checkBox2
-            // 
-            this.checkBox2.AutoSize = true;
-            this.checkBox2.Location = new System.Drawing.Point(11, 102);
-            this.checkBox2.Name = "checkBox2";
-            this.checkBox2.Size = new System.Drawing.Size(147, 17);
-            this.checkBox2.TabIndex = 31;
-            this.checkBox2.Text = "Replace unknown blocks";
-            this.checkBox2.UseVisualStyleBackColor = true;
-            this.checkBox2.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
             // 
             // FasterShapeStyleCheckBox
             // 
@@ -137,7 +125,7 @@
             this.StatusTextToolStripStatusLabel,
             this.StatusToolStripStatusLabel,
             this.StatusColorToolStripStatusLabel});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 177);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 145);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(228, 22);
             this.statusStrip1.TabIndex = 31;
@@ -167,8 +155,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(228, 199);
-            this.Controls.Add(this.checkBox2);
+            this.ClientSize = new System.Drawing.Size(228, 167);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.FasterShapeStyleCheckBox);
             this.Controls.Add(this.usePenToolCheckBox);
@@ -201,6 +188,5 @@
         private System.Windows.Forms.ToolStripStatusLabel StatusToolStripStatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel StatusColorToolStripStatusLabel;
         private System.Windows.Forms.CheckBox FasterShapeStyleCheckBox;
-        private System.Windows.Forms.CheckBox checkBox2;
     }
 }

--- a/EEditor/SettingsForm.cs
+++ b/EEditor/SettingsForm.cs
@@ -37,7 +37,6 @@ namespace EEditor
             selectAllBorderCheckBox.Checked = MainForm.userdata.selectAllBorder;
             confirmCloseCheckBox.Checked = MainForm.userdata.confirmClose;
             FasterShapeStyleCheckBox.Checked = MainForm.userdata.fastshape;
-            checkBox2.Checked = MainForm.userdata.replaceit;
             #endregion
 
             clearComboBox.SelectedIndex = 0; //Show "Clear settings..." by default
@@ -228,12 +227,6 @@ namespace EEditor
             {
                 MainForm.editArea.MainForm.rebuildGUI(false);
             }
-        }
-
-
-        private void checkBox2_CheckedChanged(object sender, EventArgs e)
-        {
-            MainForm.userdata.replaceit = checkBox2.Checked;
         }
     }
 }

--- a/EEditor/Statistics.Designer.cs
+++ b/EEditor/Statistics.Designer.cs
@@ -41,7 +41,6 @@
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(289, 270);
             this.panel1.TabIndex = 2;
-            this.panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.Panel1_Paint);
             // 
             // fgradioButton
             // 
@@ -54,7 +53,6 @@
             this.fgradioButton.TabIndex = 3;
             this.fgradioButton.TabStop = true;
             this.fgradioButton.UseVisualStyleBackColor = true;
-            this.fgradioButton.CheckedChanged += new System.EventHandler(this.FgradioButton_CheckedChanged);
             // 
             // actradioButton
             // 
@@ -96,7 +94,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(313, 345);
+            this.ClientSize = new System.Drawing.Size(313, 289);
             this.Controls.Add(this.decorradioButton);
             this.Controls.Add(this.bgradioButton);
             this.Controls.Add(this.actradioButton);

--- a/EEditor/Statistics.cs
+++ b/EEditor/Statistics.cs
@@ -54,22 +54,6 @@ namespace EEditor
             sortby(0);
         }
 
-        private void Button1_Click(object sender, EventArgs e)
-        {
-
-
-        }
-
-        private void Panel1_Paint(object sender, PaintEventArgs e)
-        {
-
-        }
-
-        private void FgradioButton_CheckedChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void sortby(int id)
         {
             int position = 0, total = 0, wposition = 4;


### PR DESCRIPTION
- Statistics moved next to history
- Hid statistics categories (as they do nothing atm)
- Renamed EEditor and EE level import/export options to be more clear
- Moved maze generation (hidden) under shapes
- Moved background ignore and replace unknown options to find/replace tool
- Redesigned fill/replace buttons a bit for better UX